### PR TITLE
cniovs: Add missing error check

### DIFF
--- a/cniovs/cniovs/cniovs.go
+++ b/cniovs/cniovs/cniovs.go
@@ -86,6 +86,9 @@ func (cniOvs CniOvs) AddOnHost(conf *usrsptypes.NetConf, args *skel.CmdArgs, ipR
 		if len(ipResult.IPs) != 0 {
 		}
 	}
+	if err != nil {
+		return err
+	}
 
 	//
 	// Save Config - Save Create Data for Delete


### PR DESCRIPTION
Before this change, when NetType had "bridge" value, the `err`
variable was initialized, but it was not returned.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>