### PR TITLE
cniovs: Add missing error check for ovs-vsctl add-port

### DIFF
--- a/cniovs/cniovs/cniovs.go
+++ b/cniovs/cniovs/cniovs.go
@@ -178,10 +178,14 @@ func addLocalDeviceVhost(conf *usrsptypes.NetConf, args *skel.CmdArgs, data *ovs
 	if vhostName, err := createVhostPort(sockDir, sockRef); err == nil {
 		if vhostPortMac, err := getVhostPortMac(vhostName); err == nil {
 			data.VhostMac = vhostPortMac
+		} else {
+			return err
 		}
 
 		data.Vhostname = vhostName
 		data.IfMac = generateRandomMacAddress()
+	} else {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Before this change, when attempting to run ovs-vsctl, any errors were
swallowed and not returned.

Signed-off-by: Benn Linger <benn@bennlinger.com>