### PR TITLE
Travis CI build and Ubuntu build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before-install:
   - sudo apt-get update -qq
 
 script:
+  - make install-dep
   - make install
   - make
   - make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
-before-install:
+before_install:
   - sudo apt-get update -qq
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ ifeq ($(PKG),rpm)
 	@$(SUDO) -E cp tmpvpp/usr/share/vpp/api/*.json /usr/share/vpp/api/.
 else ifeq ($(PKG),deb)
 	@$(SUDO) -E cp tmpvpp/usr/share/vpp/api/core/*.json /usr/share/vpp/api/.
+	@$(SUDO) -E cp tmpvpp/usr/share/vpp/api/plugins/*.json /usr/share/vpp/api/.
 endif
 	@$(SUDO) -E chown -R bin:bin /usr/share/vpp/
 	@echo   Installed /usr/share/vpp/api/*.json


### PR DESCRIPTION
Certain files weren't being copied to the correct directory while installing dependencies on Debian environments in the Makefile, causing the build to be unsuccessful.