### PR TITLE
Issue with IPv6 Source Based Routing

### DIFF
--- a/vendor/github.com/containernetworking/plugins/plugins/meta/sbr/main.go
+++ b/vendor/github.com/containernetworking/plugins/plugins/meta/sbr/main.go
@@ -237,7 +237,7 @@ func doRoutes(ipCfgs []*current.IPConfig, origRoutes []*types.Route, iface strin
 		if ipCfg.Version == "4" {
 			src.Mask = net.CIDRMask(32, 32)
 		} else {
-			src.Mask = net.CIDRMask(64, 64)
+			src.Mask = net.CIDRMask(128, 128)
 		}
 
 		log.Printf("Source to use %s", src.String())
@@ -258,7 +258,7 @@ func doRoutes(ipCfgs []*current.IPConfig, origRoutes []*types.Route, iface strin
 				dest.Mask = net.CIDRMask(0, 32)
 			} else {
 				dest.IP = net.IPv6zero
-				dest.Mask = net.CIDRMask(0, 64)
+				dest.Mask = net.CIDRMask(0, 128)
 			}
 
 			route := netlink.Route{


### PR DESCRIPTION
IP rule for lookup for IPv6 based source based routing is incorrectly being set in a way where it becomes applicable for all traffic.

**Various Interfaces**
[root@test1-server-01 /]# ip addr
..
4: eth0@if133: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1480 qdisc noqueue state UP group default
    link/ether ca:14:1a:73:91:d3 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet6 fd74:ca9b:172:21::16:8184/128 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::c814:1aff:fe73:91d3/64 scope link
       valid_lft forever preferred_lft forever
20: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 0a:17:54:d9:5b:ed brd ff:ff:ff:ff:ff:ff
    inet6 fd74:ca9b:3a09:868e:192:168:2:32/64 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::817:54ff:fed9:5bed/64 scope link
       valid_lft forever preferred_lft forever
49: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 32:e3:70:c0:30:c9 brd ff:ff:ff:ff:ff:ff
    inet6 fd74:ca9b:3a09:868d:192:168:2:38/64 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::30e3:70ff:fec0:30c9/64 scope link
       valid_lft forever preferred_lft forever

**Various Routing Tables**

[root@test1-server-01 /]# ip -6 route
fd74:ca9b:172:21::16:8184 dev eth0 proto kernel metric 256 pref medium
fe80::/64 dev eth0 proto kernel metric 256 pref medium
default via fe80::ecee:eeff:feee:eeee dev eth0 metric 1024 pref medium

[root@test1-server-01 /]# ip -6 route show table 100
fd74:ca9b:3a09:868d::/64 dev eth1 proto kernel metric 256 pref medium
fe80::/64 dev eth1 proto kernel metric 256 pref medium
default via fd74:ca9b:3a09:868d::1 dev eth1 metric 1024 pref medium

[root@test1-server-01 /]# ip -6 route show table 101
fd74:ca9b:3a09:868e::/64 dev eth2 proto kernel metric 256 pref medium
fe80::/64 dev eth2 proto kernel metric 256 pref medium
default via fd74:ca9b:3a09:868e::1 dev eth2 metric 1024 pref medium

**IP Rules**

[root@test1-server-01 /]# ip -6 rule
0:	from all lookup local
32764:	from all lookup 101
32765:	from all lookup 100
32766:	from all lookup main

As you can see the lookup to tables 100 and 101 is specified for all traffic and the routing table which will be looked up is now dictated by the priority.

**After applying the fix**

[root@test1-server-01 /]# ip -6 rule
0:	from all lookup local
32764:	from fd74:ca9b:3a09:868e:192:168:2:32 lookup 101
32765:	from fd74:ca9b:3a09:868d:192:168:2:38 lookup 100
32766:	from all lookup main

Now the source based routing is specified correctly for a single source IP address.
