### PR TITLE
Fix configuration save into new shared directory

### DIFF
--- a/pkg/configdata/configdata.go
+++ b/pkg/configdata/configdata.go
@@ -148,8 +148,8 @@ func SaveRemoteConfig(conf *types.NetConf,
 		fileName := fmt.Sprintf("configData-%s-%s.json", args.ContainerID[:12], args.IfName)
 		path := filepath.Join(sharedDir, fileName)
 
-		dataBytes, err := json.Marshal(configData)
-		if err == nil {
+		dataBytes, jsonErr := json.Marshal(configData)
+		if jsonErr == nil {
 			err = ioutil.WriteFile(path, dataBytes, 0644)
 		} else {
 			return pod, fmt.Errorf("ERROR: serializing REMOTE NetConf data: %v", err)


### PR DESCRIPTION
In case that shared directory doesn't exist, configdata.SaveRemoteConfig() shall create it and store configuration file into it. Due to the bug in the implementation, directory was created, but data were not saved.
Bug was fixed and trailing whitespace removed.

Signed-off-by: Martin Klozik <martinx.klozik@intel.com>