### PR TITLE
Fix error handling in k8sclient

### DIFF
--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -139,6 +139,8 @@ func WritePodAnnotation(kubeClient kubernetes.Interface, pod *v1.Pod) (*v1.Pod, 
 		return pod, err
 	}
 
+	// Keep original pod info for log message in case of failure
+	origPod := pod
 	// Update the pod
 	pod = pod.DeepCopy()
 	if resultErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -153,7 +155,7 @@ func WritePodAnnotation(kubeClient kubernetes.Interface, pod *v1.Pod) (*v1.Pod, 
 		pod, err = kubeClient.CoreV1().Pods(pod.Namespace).UpdateStatus(pod)
 		return err
 	}); resultErr != nil {
-		return nil, logging.Errorf("status update failed for pod %s/%s: %v", pod.Namespace, pod.Name, resultErr)
+		return nil, logging.Errorf("status update failed for pod %s/%s: %v", origPod.Namespace, origPod.Name, resultErr)
 	}
 	return pod, nil
 }


### PR DESCRIPTION
Error logging at WritePodAnnotations was modified to use the stored pod data. There was a possibility that pod data used in the log message might not be available in case when requested pod wasn't found or an update of its state failed.
Original code caused nil pointer dereference and application crash during unit test execution.

Signed-off-by: Martin Klozik <martinx.klozik@intel.com>