### PR TITLE
Use filepath package for safe path handling

### DIFF
--- a/cniovs/cniovs.go
+++ b/cniovs/cniovs.go
@@ -231,8 +231,9 @@ func getShortSharedDir(sharedDir string) string {
 	if len(sharedDir) >= 89 && strings.Contains(sharedDir, "empty-dir") {
 		// Format - /var/lib/kubelet/pods/<podID>/volumes/kubernetes.io~empty-dir/shared-dir
 		parts := strings.Split(sharedDir, "/")
+		// FIXME: it's not safe; can we assure that shareDir with "empty-dir" will always have at least 5 dirs?
 		podID := parts[5]
-		newSharedDir := DefaultHostVhostuserBaseDir + podID
+		newSharedDir := filepath.Join(DefaultHostVhostuserBaseDir, podID)
 		logging.Infof("getShortSharedDir: Short shared directory: %s", newSharedDir)
 		return newSharedDir
 	}

--- a/cniovs/ovsctrl.go
+++ b/cniovs/ovsctrl.go
@@ -3,6 +3,7 @@ package cniovs
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/intel/userspace-cni-network-plugin/logging"
@@ -31,11 +32,7 @@ func createVhostPort(sock_dir string, sock_name string, client bool, bridge_name
 	args := []string{"add-port", bridge_name, sock_name, "--", "set", "Interface", sock_name, type_str}
 
 	if client == true {
-		socketarg := "options:vhost-server-path=" + sock_dir
-		if sock_dir[len(sock_dir)-1] != '/' {
-			socketarg += "/"
-		}
-		socketarg += sock_name
+		socketarg := "options:vhost-server-path=" + filepath.Join(sock_dir, sock_name)
 		logging.Debugf("Additional string: %s", socketarg)
 
 		args = append(args, socketarg)
@@ -54,7 +51,7 @@ func createVhostPort(sock_dir string, sock_name string, client bool, bridge_name
 		}
 
 		// Move socket to defined dir for easier mounting
-		err = os.Rename(ovs_socket_dir+sock_name, sock_dir+sock_name)
+		err = os.Rename(filepath.Join(ovs_socket_dir, sock_name), filepath.Join(sock_dir, sock_name))
 		if err != nil {
 			logging.Errorf("Rename ERROR: %v", err)
 			err = nil

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -186,7 +187,7 @@ func setPodAnnotationMappedDir(pod *v1.Pod,
 	// it should be the same as the input data.
 	annotDataStr := pod.Annotations[AnnotKeyUsrspMappedDir]
 	if len(annotDataStr) != 0 {
-		if annotDataStr == mappedDir {
+		if filepath.Clean(annotDataStr) == filepath.Clean(mappedDir) {
 			logging.Verbosef("SetPodAnnotationMappedDir: Existing matches input. Do nothing.")
 			return modified, nil
 		} else {


### PR DESCRIPTION
Concatenation and comparison of file and directory paths were modified to use the filepath package instead of direct string operations. Using the filepath package ensures safe path operations, which eliminates issues caused by (missing or present) trailing slashes in directory paths.

Signed-off-by: Martin Klozik <martinx.klozik@intel.com>