### PR TITLE
Fix. Dockerfile overwriting go.mod

### DIFF
--- a/docker/userspacecni/Dockerfile
+++ b/docker/userspacecni/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -y \
     && rm -rf /var/lib/apt/lists/*
 ENV PATH="${PATH}:/usr/local/go/bin"
 RUN go mod download \
-    && go get go.fd.io/govpp/binapigen/vppapi@v0.7.0 \
+    && go get go.fd.io/govpp/binapigen/vppapi@v0.10.0 \
     && make generate \
     && go mod tidy \
     && make generate-bin

--- a/docker/userspacecni/Dockerfile.unittest
+++ b/docker/userspacecni/Dockerfile.unittest
@@ -8,7 +8,7 @@ RUN apt-get update -y \
     && rm -rf /var/lib/apt/lists/*
 ENV PATH="${PATH}:/usr/local/go/bin"
 RUN go mod download \
-    && go get go.fd.io/govpp/binapigen/vppapi@v0.7.0 \
+    && go get go.fd.io/govpp/binapigen/vppapi@v0.10.0 \
     && make generate \
     && go mod tidy \
     && make generate-bin


### PR DESCRIPTION
Code was tested with a different version of govpp due to version specified in dockerfile being different to the one in go.mod