### PR TITLE
Adding OpenSSF Best Practices Badge to the README & other achievements not there

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![CodeQL](https://github.com/intel/userspace-cni-network-plugin/actions/workflows/codeql.yml/badge.svg?branch=main) 
 [![Go Report Card](https://goreportcard.com/badge/github.com/intel/userspace-cni-network-plugin)](https://goreportcard.com/report/github.com/intel/userspace-cni-network-plugin) 
 [![Go Reference](https://pkg.go.dev/badge/github.com/intel/userspace-cni-network-plugin.svg)](https://pkg.go.dev/github.com/intel/userspace-cni-network-plugin) 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/7382/badge)](https://www.bestpractices.dev/projects/7382)
 
    * [Links](#links)
    * [BiWeekly Meeting](#biweekly-meeting)


### PR DESCRIPTION
Doing this to make the project compliant with the achievements criteria for the silver OpenSSF Best Practices Badge. It is left draft incase there are more achievements that I am not aware of